### PR TITLE
CNF-12621: Add Assisted Installer reference templates

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Main Suite")
+}
+
+var _ = Describe("initConfigMapTemplates", func() {
+	var (
+		c   client.Client
+		ctx = context.Background()
+		log logr.Logger
+	)
+
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		log = ctrl.Log.WithName("controllers").WithName("SiteConfig")
+
+		siteConfigNS := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: SiteConfigNamespace,
+			},
+		}
+		Expect(c.Create(ctx, siteConfigNS)).To(Succeed())
+	})
+
+	It("should create default assisted install cluster templates on initialization", func() {
+		err := initConfigMapTemplates(ctx, c, log)
+		Expect(err).ToNot(HaveOccurred())
+
+		aiClusterCM := &corev1.ConfigMap{}
+		key := types.NamespacedName{
+			Name:      AssistedInstallerClusterTemplates,
+			Namespace: SiteConfigNamespace,
+		}
+		Expect(c.Get(ctx, key, aiClusterCM)).To(Succeed())
+	})
+
+	It("should create default assisted install node templates on initialization", func() {
+		err := initConfigMapTemplates(ctx, c, log)
+		Expect(err).ToNot(HaveOccurred())
+
+		aiNodeCM := &corev1.ConfigMap{}
+		key := types.NamespacedName{
+			Name:      AssistedInstallerNodeTemplates,
+			Namespace: SiteConfigNamespace,
+		}
+		Expect(c.Get(ctx, key, aiNodeCM)).To(Succeed())
+	})
+
+	It("should not throw an error if a ConfigMap template already exists", func() {
+		data := map[string]string{"test": "foobar"}
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      AssistedInstallerNodeTemplates,
+				Namespace: SiteConfigNamespace,
+			},
+			Data: data,
+		}
+		Expect(c.Create(ctx, cm)).To(Succeed())
+
+		key := types.NamespacedName{
+			Name:      AssistedInstallerNodeTemplates,
+			Namespace: SiteConfigNamespace,
+		}
+
+		err := initConfigMapTemplates(ctx, c, log)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify that the existing ConfigMap is not over-written
+		aiNodeCM := &corev1.ConfigMap{}
+		Expect(c.Get(ctx, key, aiNodeCM)).To(Succeed())
+		Expect(aiNodeCM.Data).To(Equal(data))
+	})
+})

--- a/internal/templates/assisted-installer/template.go
+++ b/internal/templates/assisted-installer/template.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+*/
+
+package assistedinstaller
+
+const AgentClusterInstall = `apiVersion: extensions.hive.openshift.io/v1beta1
+kind: AgentClusterInstall
+metadata:
+  name: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Site.ClusterName }}"
+  annotations:
+{{ if .SpecialVars.InstallConfigOverrides }}
+    agent-install.openshift.io/install-config-overrides: '{{ .SpecialVars.InstallConfigOverrides }}'
+{{ end }}
+    metaclusterinstall.openshift.io/sync-wave: "1"
+spec:
+  clusterDeploymentRef:
+    name: "{{ .Site.ClusterName }}"
+  holdInstallation: {{ .Site.HoldInstallation }}
+  imageSetRef:
+    name: "{{ .Site.ClusterImageSetNameRef }}"
+{{ if .Site.ApiVIPs }}
+  apiVIPs:
+{{ .Site.ApiVIPs | toYaml | indent 4 }}
+{{ end }}
+{{ if .Site.IngressVIPs }}
+  ingressVIPs:
+{{ .Site.IngressVIPs | toYaml | indent 4 }}
+{{ end }}
+  networking:
+{{ if .Site.ClusterNetwork }}
+    clusterNetwork:
+{{ .Site.ClusterNetwork | toYaml | indent 6 }}
+{{ end }}
+{{ if .Site.MachineNetwork }}
+    machineNetwork:
+{{ .Site.MachineNetwork | toYaml | indent 6 }}
+{{ end }}
+{{ if .Site.ServiceNetwork }}
+    serviceNetwork:
+{{ .Site.ServiceNetwork | toYaml | indent 6 }}
+{{ end }}
+  provisionRequirements:
+    controlPlaneAgents: {{ .SpecialVars.ControlPlaneAgents }}
+    workerAgents: {{ .SpecialVars.WorkerAgents }}
+{{ if (anyFieldDefined .Site.ProxySettings) }}
+  proxy:
+{{ .Site.ProxySettings | toYaml | indent 4 }}
+{{ end }}
+  sshPublicKey: "{{ .Site.SSHPublicKey }}"
+  manifestsConfigMapRef:
+    name: "{{ .Site.ClusterName }}"`
+
+const ClusterDeployment = `apiVersion: hive.openshift.io/v1
+kind: ClusterDeployment
+metadata:
+  name: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Site.ClusterName }}"
+  annotations:
+    metaclusterinstall.openshift.io/sync-wave: "1"
+spec:
+  baseDomain: "{{ .Site.BaseDomain }}"
+  clusterInstallRef:
+    group: extensions.hive.openshift.io
+    kind: AgentClusterInstall
+    name: "{{ .Site.ClusterName }}"
+    version: v1beta1
+  clusterName: "{{ .Site.ClusterName }}"
+  platform:
+    agentBareMetal:
+      agentSelector:
+        matchLabels:
+          cluster-name: "{{ .Site.ClusterName }}"
+  pullSecretRef:
+    name: "{{ .Site.PullSecretRef.Name }}"`
+
+const InfraEnv = `apiVersion: agent-install.openshift.io/v1beta1
+kind: InfraEnv
+metadata:
+  annotations:
+    metaclusterinstall.openshift.io/sync-wave: "1"
+  name: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Site.ClusterName }}"
+spec:
+  clusterRef:
+    name: "{{ .Site.ClusterName }}"
+    namespace: "{{ .Site.ClusterName }}"
+  sshAuthorizedKey: "{{ .Site.SSHPublicKey }}"
+{{ if (anyFieldDefined .Site.ProxySettings) }}
+  proxy:
+{{ .Site.ProxySettings | toYaml | indent 4 }}
+{{ end }}
+  pullSecretRef:
+    name: "{{ .Site.PullSecretRef.Name }}"
+  ignitionConfigOverride: {{ .Site.IgnitionConfigOverride }}
+  nmStateConfigLabelSelector:
+    matchLabels:
+      nmstate-label: "{{ .Site.ClusterName }}"
+  additionalNTPSources:
+{{ .Site.AdditionalNTPSources | toYaml | indent 4 }}`
+
+const KlusterletAddonConfig = `apiVersion: agent.open-cluster-management.io/v1
+kind: KlusterletAddonConfig
+metadata:
+  annotations:
+    metaclusterinstall.openshift.io/sync-wave: "2"
+  name: "{{ .Site.ClusterName }}"
+  namespace: "{{ .Site.ClusterName }}"
+spec:
+  clusterName: "{{ .Site.ClusterName }}"
+  clusterNamespace: "{{ .Site.ClusterName }}"
+  clusterLabels:
+    cloud: auto-detect
+    vendor: auto-detect
+  applicationManager:
+    enabled: false
+  certPolicyController:
+    enabled: false
+  iamPolicyController:
+    enabled: false
+  policyController:
+    enabled: true
+  searchCollector:
+    enabled: false`
+
+const NMStateConfig = `apiVersion: agent-install.openshift.io/v1beta1
+kind: NMStateConfig
+metadata:
+  annotations:
+    metaclusterinstall.openshift.io/sync-wave: "1"
+  name: "{{ .SpecialVars.CurrentNode.HostName }}"
+  namespace: "{{ .Site.ClusterName }}"
+  labels:
+    nmstate-label: "{{ .Site.ClusterName }}"
+spec:
+  config:
+{{ .SpecialVars.CurrentNode.NodeNetwork.NetConfig | toYaml | indent 4}}
+  interfaces:
+{{ .SpecialVars.CurrentNode.NodeNetwork.Interfaces | toYaml | indent 4 }}`
+
+const ManagedCluster = `apiVersion: cluster.open-cluster-management.io/v1
+kind: ManagedCluster
+metadata:
+  name: "{{ .Site.ClusterName }}"
+  labels:
+{{ .Site.ClusterLabels | toYaml | indent 4 }}
+  annotations:
+    metaclusterinstall.openshift.io/sync-wave: "2"
+spec:
+  hubAcceptsClient: true`
+
+const BareMetalHost = `apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: "{{ .SpecialVars.CurrentNode.HostName }}"
+  namespace: "{{ .Site.ClusterName }}"
+  annotations:
+    metaclusterinstall.openshift.io/sync-wave: "1"
+    inspect.metal3.io: "{{ .SpecialVars.CurrentNode.IronicInspect }}"
+{{ if .SpecialVars.CurrentNode.NodeLabels }}
+    bmac.agent-install.openshift.io.node-label:
+{{ .SpecialVars.CurrentNode.NodeLabels | toYaml | indent 6 }}
+{{ end }}
+    bmac.agent-install.openshift.io/hostname: "{{ .SpecialVars.CurrentNode.HostName }}"
+{{ if .SpecialVars.CurrentNode.InstallerArgs  }}
+    bmac.agent-install.openshift.io/installer-args: {{ .SpecialVars.CurrentNode.InstallerArgs  }}
+{{ end }}
+{{ if .SpecialVars.CurrentNode.IgnitionConfigOverride }}
+    bmac.agent-install.openshift.io/ignition-config-overrides: {{ .SpecialVars.CurrentNode.IgnitionConfigOverride }}
+{{ end }}
+    bmac.agent-install.openshift.io/role: "{{ .SpecialVars.CurrentNode.Role }}"
+  labels:
+    infraenvs.agent-install.openshift.io: "{{ .Site.ClusterName }}"
+spec:
+  bootMode: "{{ .SpecialVars.CurrentNode.BootMode }}"
+  bmc:
+    address: "{{ .SpecialVars.CurrentNode.BmcAddress }}"
+    disableCertificateVerification: true
+    credentialsName: "{{ .SpecialVars.CurrentNode.BmcCredentialsName.Name }}"
+  bootMACAddress: "{{ .SpecialVars.CurrentNode.BootMACAddress }}"
+  automatedCleaningMode: "{{ .SpecialVars.CurrentNode.AutomatedCleaningMode }}"
+  online: true
+{{ if (anyFieldDefined .SpecialVars.CurrentNode.RootDeviceHints) }}
+  rootDeviceHints:
+{{ .SpecialVars.CurrentNode.RootDeviceHints | toYaml | indent 4 }}
+{{ end }}`
+
+func GetClusterTemplates() map[string]string {
+	data := make(map[string]string)
+	data["AgentClusterInstall"] = AgentClusterInstall
+	data["ClusterDeployment"] = ClusterDeployment
+	data["InfraEnv"] = InfraEnv
+	data["ManagedCluster"] = ManagedCluster
+	data["KlusterletAddonConfig"] = KlusterletAddonConfig
+	return data
+}
+
+func GetNodeTemplates() map[string]string {
+	data := make(map[string]string)
+	data["BareMetalHost"] = BareMetalHost
+	data["NMStateConfig"] = NMStateConfig
+	return data
+}


### PR DESCRIPTION
This PR contains the following additions:
- Assisted Installer reference templates
- Functionality to create the reference ConfigMaps on initialization of the SiteConfig operator.