### PR TITLE
CNF-12950: Create ClusterDeployment controller for SiteConfig

### DIFF
--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -24,9 +24,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
+const (
+	Group          = "metaclusterinstall.openshift.io"
+	Version        = "v1alpha1"
+	SiteConfigKind = "SiteConfig"
+)
+
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "metaclusterinstall.openshift.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: Group, Version: Version}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/internal/controller/clusterdeployment_reconciler.go
+++ b/internal/controller/clusterdeployment_reconciler.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/sakhoury/siteconfig/internal/controller/conditions"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// ClusterDeploymentReconciler reconciles a ClusterDeployment object to
+// update the SiteConfig cluster deployment status conditions
+type ClusterDeploymentReconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+func (r *ClusterDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Get the ClusterDeployment CR
+	clusterDeployment := &hivev1.ClusterDeployment{}
+	if err := r.Get(ctx, req.NamespacedName, clusterDeployment); err != nil {
+		if errors.IsNotFound(err) {
+			r.Log.Info("ClusterDeployment not found", "name", clusterDeployment.Name)
+			return doNotRequeue(), nil
+		}
+		r.Log.Error(err, "Failed to get ClusterDeployment")
+		// This is likely a case where the API is down, so requeue and try again shortly
+		return requeueWithError(err)
+	}
+
+	// Fetch SiteConfig associated with ClusterDeployment object
+	siteConfig, err := r.getSiteConfig(ctx, clusterDeployment)
+	if siteConfig == nil {
+		return doNotRequeue(), nil
+	} else if err != nil {
+		return requeueWithError(err)
+	}
+
+	patch := client.MergeFrom(siteConfig.DeepCopy())
+
+	// Initialize siteconfig clusterdeployment reference if unset
+	if siteConfig.Status.ClusterDeploymentRef == nil || siteConfig.Status.ClusterDeploymentRef.Name == "" {
+		siteConfig.Status.ClusterDeploymentRef = &corev1.LocalObjectReference{Name: clusterDeployment.Name}
+	}
+
+	updateSCProvisionedStatus(clusterDeployment, siteConfig)
+	updateSCDeploymentConditions(clusterDeployment, siteConfig)
+	if updateErr := conditions.PatchStatus(ctx, r.Client, siteConfig, patch); updateErr != nil {
+		return requeueWithError(updateErr)
+	}
+
+	return doNotRequeue(), nil
+}
+
+func clusterInstallConditionTypes() []hivev1.ClusterDeploymentConditionType {
+	return []hivev1.ClusterDeploymentConditionType{
+		hivev1.ClusterInstallRequirementsMetClusterDeploymentCondition,
+		hivev1.ClusterInstallCompletedClusterDeploymentCondition,
+		hivev1.ClusterInstallFailedClusterDeploymentCondition,
+		hivev1.ClusterInstallStoppedClusterDeploymentCondition,
+	}
+}
+
+func updateSCProvisionedStatus(cd *hivev1.ClusterDeployment, sc *v1alpha1.SiteConfig) {
+	// Check if cluster has finished installing, if it has -> update siteConfig.Status.Conditions(Provisioned -> Completed)
+	if cd.Spec.Installed {
+		conditions.SetStatusCondition(&sc.Status.Conditions,
+			conditions.Provisioned,
+			conditions.Completed,
+			metav1.ConditionTrue,
+			"Provision completed")
+	} else if installStopped := conditions.FindConditionType(cd.Status.Conditions, hivev1.ClusterInstallStoppedClusterDeploymentCondition); installStopped != nil {
+		// Check if siteconfig.Status Provisioned -> InProgress condition
+		if found := meta.FindStatusCondition(sc.Status.Conditions, string(conditions.Provisioned)); found == nil {
+			if !cd.Spec.Installed && installStopped.Status == corev1.ConditionStatus(metav1.ConditionFalse) {
+				conditions.SetStatusCondition(&sc.Status.Conditions,
+					conditions.Provisioned,
+					conditions.InProgress,
+					metav1.ConditionTrue,
+					"Provisioning cluster")
+			}
+		}
+	}
+}
+
+func updateSCDeploymentConditions(cd *hivev1.ClusterDeployment, sc *v1alpha1.SiteConfig) {
+	// Compare siteConfig.Status.installConditions to clusterDeployment.Conditions
+	for _, cond := range clusterInstallConditionTypes() {
+		installCond := conditions.FindConditionType(cd.Status.Conditions, cond)
+		if installCond == nil {
+			// not found, initialize with Unknown fields
+			installCond = &hivev1.ClusterDeploymentCondition{
+				Type:    cond,
+				Status:  corev1.ConditionUnknown,
+				Reason:  "Unknown",
+				Message: "Unknown"}
+		}
+
+		now := metav1.NewTime(time.Now())
+
+		// Search SiteConfig status DeploymentConditions for the installCond
+		scCond := conditions.FindConditionType(sc.Status.DeploymentConditions, installCond.Type)
+		if scCond == nil {
+			installCond.LastTransitionTime = now
+			installCond.LastProbeTime = now
+			sc.Status.DeploymentConditions = append(sc.Status.DeploymentConditions, *installCond)
+		} else {
+			scCond.Status = installCond.Status
+			scCond.Reason = installCond.Reason
+			scCond.Message = installCond.Message
+			scCond.LastProbeTime = now
+
+			if scCond.Status != installCond.Status {
+				scCond.LastTransitionTime = now
+			}
+		}
+	}
+}
+
+func siteConfigOwner(ownerRefs []metav1.OwnerReference) string {
+	for _, ownerRef := range ownerRefs {
+		if ownerRef.Kind == v1alpha1.SiteConfigKind {
+			return ownerRef.Name
+		}
+	}
+	return ""
+}
+func isOwnedBySiteConfig(ownerRefs []metav1.OwnerReference) bool {
+	return siteConfigOwner(ownerRefs) != ""
+}
+
+func (r *ClusterDeploymentReconciler) getSiteConfig(ctx context.Context, cd *hivev1.ClusterDeployment) (*v1alpha1.SiteConfig, error) {
+	siteConfigRef := siteConfigOwner(cd.GetOwnerReferences())
+	if siteConfigRef == "" {
+		r.Log.Info("SiteConfig owner-reference not found for ClusterDeployment", "name", cd.Name)
+		return nil, nil
+	}
+
+	siteConfig := &v1alpha1.SiteConfig{}
+	if err := r.Get(ctx, types.NamespacedName{Name: siteConfigRef, Namespace: cd.Namespace}, siteConfig); err != nil {
+		if errors.IsNotFound(err) {
+			r.Log.Info("SiteConfig not found", "name", siteConfigRef)
+			return nil, nil
+		}
+		r.Log.Info("Failed to get SiteConfig", "name", siteConfigRef, "ClusterDeployment", cd.Name)
+		return nil, err
+	}
+	return siteConfig, nil
+}
+
+func (r *ClusterDeploymentReconciler) mapSiteConfigToCD(ctx context.Context, obj client.Object) []reconcile.Request {
+	siteConfig := &v1alpha1.SiteConfig{}
+	if err := r.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, siteConfig); err != nil {
+		return []reconcile.Request{}
+	}
+
+	if siteConfig.Status.ClusterDeploymentRef != nil &&
+		siteConfig.Status.ClusterDeploymentRef.Name != "" {
+		return []reconcile.Request{{
+			NamespacedName: types.NamespacedName{
+				Namespace: obj.GetNamespace(),
+				Name:      siteConfig.Status.ClusterDeploymentRef.Name,
+			},
+		}}
+	}
+
+	return []reconcile.Request{}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("clusterDeploymentReconciler").
+		For(&hivev1.ClusterDeployment{},
+			// watch for create and update event for ClusterDeployment
+			builder.WithPredicates(predicate.Funcs{
+				GenericFunc: func(e event.GenericEvent) bool { return false },
+				CreateFunc: func(e event.CreateEvent) bool {
+					return isOwnedBySiteConfig(e.Object.GetOwnerReferences())
+				},
+				DeleteFunc: func(e event.DeleteEvent) bool { return false },
+				UpdateFunc: func(e event.UpdateEvent) bool {
+					return isOwnedBySiteConfig(e.ObjectNew.GetOwnerReferences())
+				},
+			})).
+		WatchesRawSource(source.Kind(mgr.GetCache(), &v1alpha1.SiteConfig{}), handler.EnqueueRequestsFromMapFunc(r.mapSiteConfigToCD)).
+		Complete(r)
+}

--- a/internal/controller/clusterdeployment_reconciler_test.go
+++ b/internal/controller/clusterdeployment_reconciler_test.go
@@ -1,0 +1,359 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	hivev1 "github.com/openshift/hive/apis/hive/v1"
+	"github.com/sakhoury/siteconfig/api/v1alpha1"
+	"github.com/sakhoury/siteconfig/internal/controller/conditions"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Reconcile", func() {
+	var (
+		c                client.Client
+		r                *ClusterDeploymentReconciler
+		ctx              = context.Background()
+		clusterName      = "test-cluster"
+		clusterNamespace = "test-namespace"
+		siteConfig       *v1alpha1.SiteConfig
+	)
+	BeforeEach(func() {
+		c = fakeclient.NewClientBuilder().
+			WithScheme(scheme.Scheme).
+			WithStatusSubresource(&v1alpha1.SiteConfig{}).
+			Build()
+		testLogger := ctrl.Log.WithName("ClusterDeploymentReconciler")
+		r = &ClusterDeploymentReconciler{
+			Client: c,
+			Scheme: scheme.Scheme,
+			Log:    testLogger,
+		}
+
+		siteConfig = &v1alpha1.SiteConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       clusterName,
+				Namespace:  clusterNamespace,
+				Finalizers: []string{siteConfigFinalizer},
+			},
+			Spec: v1alpha1.SiteConfigSpec{
+				ClusterName:            clusterName,
+				PullSecretRef:          &corev1.LocalObjectReference{Name: "pull-secret"},
+				ClusterImageSetNameRef: "testimage:foobar",
+				SSHPublicKey:           "test-ssh",
+				BaseDomain:             "abcd",
+				ClusterType:            v1alpha1.ClusterTypeSNO,
+				TemplateRefs: []v1alpha1.TemplateRef{
+					{Name: "test-cluster-template", Namespace: "default"}},
+				Nodes: []v1alpha1.NodeSpec{{
+					BmcAddress:         "1:2:3:4",
+					BmcCredentialsName: v1alpha1.BmcCredentialsName{Name: "bmc"},
+					TemplateRefs: []v1alpha1.TemplateRef{
+						{Name: "test-node-template", Namespace: "default"}}}}},
+		}
+
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: clusterNamespace,
+			},
+		}
+		Expect(c.Create(ctx, ns)).To(Succeed())
+		Expect(c.Create(ctx, siteConfig)).To(Succeed())
+	})
+
+	It("doesn't error for a missing ClusterDeployment", func() {
+		key := types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		}
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+	})
+
+	It("doesn't reconcile a ClusterDeployment that is not owned by SiteConfig", func() {
+		key := types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		}
+		clusterDeployment := &hivev1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: clusterNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "foobar.group.io",
+						Kind:       "foobar",
+						Name:       clusterName,
+					},
+				},
+			},
+			Status: hivev1.ClusterDeploymentStatus{
+				Conditions: []hivev1.ClusterDeploymentCondition{
+					{
+						Type:    hivev1.ClusterInstallFailedClusterDeploymentCondition,
+						Status:  corev1.ConditionStatus(metav1.ConditionFalse),
+						Reason:  "InstallationNotFailed",
+						Message: "The installation has not failed"},
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterDeployment)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		// Fetch SiteConfig and verify that the status is unchanged
+		sc := &v1alpha1.SiteConfig{}
+		Expect(c.Get(ctx, key, sc)).To(Succeed())
+		Expect(sc.Status).To(Equal(siteConfig.Status))
+	})
+
+	It("tests that ClusterDeploymentReconciler initializes SiteConfig ClusterDeployment correctly", func() {
+		key := types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		}
+		clusterDeployment := &hivev1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: clusterNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "metaclusterinstall.openshift.io/v1alpha1",
+						Kind:       v1alpha1.SiteConfigKind,
+						Name:       clusterName,
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterDeployment)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(doNotRequeue()))
+
+		expectedConditions := []hivev1.ClusterDeploymentCondition{
+			{
+				Type:    hivev1.ClusterInstallRequirementsMetClusterDeploymentCondition,
+				Status:  corev1.ConditionStatus(metav1.ConditionUnknown),
+				Message: "Unknown",
+			},
+			{
+				Type:    hivev1.ClusterInstallStoppedClusterDeploymentCondition,
+				Status:  corev1.ConditionStatus(metav1.ConditionUnknown),
+				Message: "Unknown",
+			},
+			{
+				Type:    hivev1.ClusterInstallCompletedClusterDeploymentCondition,
+				Status:  corev1.ConditionStatus(metav1.ConditionUnknown),
+				Message: "Unknown",
+			},
+			{
+				Type:    hivev1.ClusterInstallFailedClusterDeploymentCondition,
+				Status:  corev1.ConditionStatus(metav1.ConditionUnknown),
+				Message: "Unknown",
+			},
+		}
+
+		sc := &v1alpha1.SiteConfig{}
+		Expect(c.Get(ctx, key, sc)).To(Succeed())
+		Expect(sc.Status.ClusterDeploymentRef.Name).To(Equal(clusterName))
+		Expect(len(sc.Status.DeploymentConditions)).To(Equal(len(expectedConditions)))
+
+		for _, cond := range expectedConditions {
+			matched := false
+			for i := range sc.Status.DeploymentConditions {
+				if sc.Status.DeploymentConditions[i].Type == cond.Type &&
+					sc.Status.DeploymentConditions[i].Status == cond.Status {
+					matched = true
+				}
+			}
+			Expect(matched).To(Equal(true), "Condition %s was not found", cond.Type)
+		}
+	})
+
+	It("tests that ClusterDeploymentReconciler updates SiteConfig deploymentConditions", func() {
+		key := types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		}
+		clusterDeployment := &hivev1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: clusterNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "metaclusterinstall.openshift.io/v1alpha1",
+						Kind:       v1alpha1.SiteConfigKind,
+						Name:       clusterName,
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterDeployment)).To(Succeed())
+
+		Expect(c.Get(ctx, key, siteConfig)).To(Succeed())
+		conditions.SetStatusCondition(&siteConfig.Status.Conditions,
+			conditions.Provisioned,
+			conditions.InProgress,
+			metav1.ConditionTrue,
+			"Provisioning cluster")
+		err := conditions.UpdateStatus(ctx, c, siteConfig)
+		Expect(err).ToNot(HaveOccurred())
+
+		sc := &v1alpha1.SiteConfig{}
+		Expect(c.Get(ctx, key, sc)).To(Succeed())
+
+		DeploymentConditions := [][]hivev1.ClusterDeploymentCondition{
+			{
+				{
+					Type:    hivev1.ClusterInstallRequirementsMetClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionFalse),
+					Reason:  "ClusterNotReady",
+					Message: "The cluster is not ready to begin the installation",
+				},
+				{
+					Type:    hivev1.ClusterInstallStoppedClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionFalse),
+					Reason:  "InstallationNotStopped",
+					Message: "The installation is waiting to start or in progress",
+				},
+				{
+					Type:    hivev1.ClusterInstallCompletedClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionTrue),
+					Reason:  "InstallationNotFailed",
+					Message: "The installation has not started",
+				},
+				{
+					Type:    hivev1.ClusterInstallFailedClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionFalse),
+					Reason:  "InstallationNotFailed",
+					Message: "The installation has not started",
+				},
+			},
+
+			{
+				{
+					Type:    hivev1.ClusterInstallRequirementsMetClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionTrue),
+					Reason:  "ClusterInstallationStopped",
+					Message: "The cluster installation stopped",
+				},
+				{
+					Type:    hivev1.ClusterInstallStoppedClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionTrue),
+					Reason:  "ClusterInstallStopped",
+					Message: "The installation has stopped because it completed successfully",
+				},
+				{
+					Type:    hivev1.ClusterInstallCompletedClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionTrue),
+					Reason:  "InstallationCompleted",
+					Message: "The installation has completed: Cluster is installed",
+				},
+				{
+					Type:    hivev1.ClusterInstallFailedClusterDeploymentCondition,
+					Status:  corev1.ConditionStatus(metav1.ConditionFalse),
+					Reason:  "InstallationNotFailed",
+					Message: "The installation has not failed",
+				},
+			},
+		}
+
+		for _, deploymentCondition := range DeploymentConditions {
+			clusterDeployment.Status.Conditions = deploymentCondition
+			Expect(c.Update(ctx, clusterDeployment)).To(Succeed())
+
+			res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res).To(Equal(doNotRequeue()))
+
+			sc := &v1alpha1.SiteConfig{}
+			Expect(c.Get(ctx, key, sc)).To(Succeed())
+
+			for _, cond := range deploymentCondition {
+				matched := false
+				for i := range sc.Status.DeploymentConditions {
+					if sc.Status.DeploymentConditions[i].Type == cond.Type &&
+						sc.Status.DeploymentConditions[i].Status == cond.Status &&
+						sc.Status.DeploymentConditions[i].Message == cond.Message &&
+						sc.Status.DeploymentConditions[i].Reason == cond.Reason {
+						matched = true
+					}
+				}
+				Expect(matched).To(Equal(true), "Condition %s was not found", cond.Type)
+			}
+		}
+	})
+
+	It("tests that SiteConfig status condition is set to provisioned when cluster is installed", func() {
+		key := types.NamespacedName{
+			Namespace: clusterNamespace,
+			Name:      clusterName,
+		}
+		clusterDeployment := &hivev1.ClusterDeployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      clusterName,
+				Namespace: clusterNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion: "metaclusterinstall.openshift.io/v1alpha1",
+						Kind:       v1alpha1.SiteConfigKind,
+						Name:       clusterName,
+					},
+				},
+			},
+		}
+		Expect(c.Create(ctx, clusterDeployment)).To(Succeed())
+
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Set cluster installed -> true
+		clusterDeployment.Spec.Installed = true
+		Expect(c.Update(ctx, clusterDeployment)).To(Succeed())
+
+		res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(Equal(ctrl.Result{}))
+
+		sc := &v1alpha1.SiteConfig{}
+		Expect(c.Get(ctx, key, sc)).To(Succeed())
+
+		found := false
+		for i := range sc.Status.Conditions {
+			if sc.Status.Conditions[i].Type == string(conditions.Provisioned) &&
+				sc.Status.Conditions[i].Status == metav1.ConditionTrue {
+				found = true
+			}
+		}
+		Expect(found).To(Equal(true))
+	})
+})

--- a/internal/controller/siteconfig_controller.go
+++ b/internal/controller/siteconfig_controller.go
@@ -224,7 +224,7 @@ func (r *SiteConfigReconciler) handleValidate(ctx context.Context, siteConfig *v
 			"Validation succeeded")
 	}
 	r.Log.Info("Finished validation", "SiteConfig", siteConfig.Name)
-	return conditions.UpdateSiteConfigStatus(ctx, r.Client, siteConfig)
+	return conditions.UpdateStatus(ctx, r.Client, siteConfig)
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
This PR introduces a new ClusterDeployment controller for the SiteConfig controller. This controller handles all ClusterDeployment related events pertinent to the SiteConfig.