### PR TITLE
Suppress manifest by kind

### DIFF
--- a/internal/controller/siteconfig_builder_test.go
+++ b/internal/controller/siteconfig_builder_test.go
@@ -420,8 +420,8 @@ var _ = Describe("renderTemplates", func() {
 		clusterTemplates := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: "cluster-level", Namespace: "test"},
 			Data: map[string]string{
-				"TestA": getMockBasicClusterTemplate("TestA"),
-				"TestB": getMockBasicClusterTemplate("TestB"),
+				"TestA_Foobar": getMockBasicClusterTemplate("TestA"),
+				"TestB":        getMockBasicClusterTemplate("TestB"),
 			},
 		}
 		Expect(c.Create(ctx, clusterTemplates)).To(Succeed())

--- a/internal/controller/siteconfig_helper.go
+++ b/internal/controller/siteconfig_helper.go
@@ -160,8 +160,8 @@ func buildSiteData(siteConfig *v1alpha1.SiteConfig, node *v1alpha1.NodeSpec) (da
 	return
 }
 
-// suppressRenderingManifest function returns true if the manifest-rendering should be suppressed
-func suppressRenderingManifest(kind string, suppressedManifests []string) bool {
+// suppressManifest function returns true if the manifest-rendering should be suppressed
+func suppressManifest(kind string, suppressedManifests []string) bool {
 	if kind == "" || len(suppressedManifests) == 0 {
 		return false
 	}

--- a/internal/controller/siteconfig_helper_test.go
+++ b/internal/controller/siteconfig_helper_test.go
@@ -257,7 +257,7 @@ func Test_buildSiteData(t *testing.T) {
 
 }
 
-func Test_suppressRenderingManifest(t *testing.T) {
+func Test_suppressManifest(t *testing.T) {
 	type args struct {
 		kind                string
 		suppressedManifests []string
@@ -306,8 +306,8 @@ func Test_suppressRenderingManifest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := suppressRenderingManifest(tt.args.kind, tt.args.suppressedManifests); got != tt.want {
-				t.Errorf("suppressRenderingManifest() = %v, want %v", got, tt.want)
+			if got := suppressManifest(tt.args.kind, tt.args.suppressedManifests); got != tt.want {
+				t.Errorf("suppressManifest() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The current implementation suppresses manifests using the template key from the ConfigMap that stores the template. Although using the resource kind as the template key is recommended, it is not always guaranteed. This commit changes the approach to extract the resource kind directly from the manifest and apply the suppression accordingly.