### PR TITLE
Rename proxy json tag to proxySettings

### DIFF
--- a/api/v1alpha1/siteconfig_types.go
+++ b/api/v1alpha1/siteconfig_types.go
@@ -274,7 +274,7 @@ type SiteConfigSpec struct {
 
 	// ProxySettings defines the proxy settings used for the install config
 	// +optional
-	ProxySettings aiv1beta1.Proxy `json:"proxy,omitempty"`
+	ProxySettings aiv1beta1.Proxy `json:"proxySettings,omitempty"`
 
 	// ExtraManifestsRefs is list of config map references containing additional manifests to be applied to the cluster.
 	// +optional

--- a/bundle/manifests/metaclusterinstall.openshift.io_siteconfigs.yaml
+++ b/bundle/manifests/metaclusterinstall.openshift.io_siteconfigs.yaml
@@ -408,7 +408,7 @@ spec:
                       type: array
                   type: object
                 type: array
-              proxy:
+              proxySettings:
                 description: ProxySettings defines the proxy settings used for the
                   install config
                 properties:

--- a/config/crd/bases/metaclusterinstall.openshift.io_siteconfigs.yaml
+++ b/config/crd/bases/metaclusterinstall.openshift.io_siteconfigs.yaml
@@ -408,7 +408,7 @@ spec:
                       type: array
                   type: object
                 type: array
-              proxy:
+              proxySettings:
                 description: ProxySettings defines the proxy settings used for the
                   install config
                 properties:


### PR DESCRIPTION
This PR renames the json tag of SiteConfigSpec.ProxySettings from proxy to proxySettings. This is to conform with the other json tags.