### PR TITLE
NO-ISSUE: Fix enhancement lint SIGPIPE failure on large files

### DIFF
--- a/hack/enhancement-lint.sh
+++ b/hack/enhancement-lint.sh
@@ -77,7 +77,7 @@ check_frontmatter() {
         return 1
     fi
 
-    if ! sed -n '2,$p' "$file" | grep -q '^---$'; then
+    if ! grep -q '^---$' <(sed -n '2,$p' "$file"); then
         echo "  ERROR: missing closing --- marker in YAML frontmatter" >&2
         return 1
     fi


### PR DESCRIPTION
## Summary
- Fix `hack/enhancement-lint.sh` failing on enhancement proposals longer than ~50 lines due to a `pipefail` + `grep -q` interaction causing SIGPIPE

## Details

When `set -euo pipefail` is enabled, `sed -n '2,$p' "$file" | grep -q '^---$'` fails on large files because `grep -q` exits immediately after finding the first match (the closing `---` marker near the top of the file), but `sed` is still writing the remaining hundreds of lines into the now-closed pipe. This triggers SIGPIPE on `sed`, which `pipefail` treats as a pipe failure.

The fix uses process substitution (`grep -q '^---$' <(sed ...)`) so `grep` reads from a file descriptor rather than a pipe, avoiding the broken-pipe condition.

## Test plan
- [x] Run `hack/enhancement-lint.sh` against a 550-line enhancement proposal — passes
- [x] Run `hack/enhancement-lint.sh` against the existing template — passes
- [x] Run `make ci-job` target includes `enhancement-lint` — no regressions

## AI usage
N/A